### PR TITLE
Rename uuid2mac to xhyve-uuid2mac for safety

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: xhyve/build/xhyve boot2docker-xhyve/uuid2ip/build/uuid2mac
 
 install: all
 	@install -CSv xhyve/build/xhyve $(PREFIX)/bin/
-	@install -CSv boot2docker-xhyve/uuid2ip/build/uuid2mac $(PREFIX)/bin/
+	@install -CSv boot2docker-xhyve/uuid2ip/build/uuid2mac $(PREFIX)/bin/xhyve-uuid2mac
 	@install -CSv dhyve $(PREFIX)/bin/
 
 xhyve/build/xhyve:

--- a/dhyve
+++ b/dhyve
@@ -138,7 +138,7 @@ vm_init () {
 
     echo -n "[dhyve] getting a mac address.."
     local uuid=$(uuidgen)
-    local mac=$(uuid2mac "$uuid")
+    local mac=$(xhyve-uuid2mac "$uuid")
     echo "$mac" > "$HOME/.dhyve/vm.mac"
     echo "done"
 


### PR DESCRIPTION
But it may be unnecessary.
