### PR TITLE
Add "tcp://" schema to DOCKER_HOST environment variable

### DIFF
--- a/dhyve
+++ b/dhyve
@@ -362,7 +362,7 @@ vm_env() {
 
     echo "unset DOCKER_TLS_VERIFY"
     echo "unset DOCKER_CERT_PATH"
-    echo "export DOCKER_HOST=$ip:2375"
+    echo "export DOCKER_HOST=tcp://$ip:2375"
 }
 
 cmd=$1


### PR DESCRIPTION
This PR simply adds the correct schema to the URI in the generated `DOCKER_HOST` environment variable.
